### PR TITLE
Support external pin validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ await resetPinCodeInternalStates()
 |**`endProcessFunction`**|Function to handle the end of the process|`None`|`false`|`(pinCode: string) => void`|
 |**`finishProcess`**|Function to be used when the user enters the right PIN code|Removes the values in AsyncStorage and set the status to `success`|`false`|`(pinCode?: string) => void`|
 |**`getCurrentPinLength`**|Function returning the length of the current PIN code|`None`|`false`|`(length: number) => void`|
-|**`handleResultEnterPin`**|Function to be used to handle the PIN code entered by the user. To be used with the **`pinStatus`** props|Functions that checks the validity of the give PIN code, stores the number of failed attempts in the `AsyncStorage` and the time the application was locked if needed|`false`|`any`|
-|**`iconComponentLockedPage`**|View component to be used between the timer and the text on the locked application page|A circular red View using the `lock` material icon|`false`|`any`|
+|**`handleResultEnterPin`**|Function to be used to handle the PIN code entered by the user. Can be used for external-custom pin validation, return boolean to override internal pin validation| undefined |`false`|(pinCode?: string) => bool or undefined|
+|**`iconComponentLockedPage`**|View component to be used between the timer and the text on the locked application page|A circular red View using the `lock` material icon|`false`|`any`| 
 |**`iconButtonDeleteDisabled`**|Boolean to remove the icon on the delete button of the PIN panel|`false`|`false`|`boolean`|
 |**`launchTouchID`**|Function to manually trigger the touchID|`undefined`|`false`|`() => void`|
 |**`lockedIconComponent`**|Component to replace the locked icon on the locked application page|`Material lock icon`|`false`|`any`|

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { PinResultStatus } from "./src/utils";
 import * as React from "react";
 import { StyleProp, ViewStyle, TextStyle } from "react-native";
@@ -115,10 +116,10 @@ declare class PINCode extends React.PureComponent<IProps, IState> {
     static defaultProps: Partial<IProps>;
     constructor(props: IProps);
     changeInternalStatus: (status: PinResultStatus) => void;
-    renderLockedPage: () => any;
-    render(): any;
+    renderLockedPage: () => JSX.Element;
+    render(): JSX.Element;
 }
-export declare function hasUserSetPinCode(serviceName?: string): Promise<any>;
-export declare function deleteUserPinCode(serviceName?: string): Promise<any>;
-export declare function resetPinCodeInternalStates(pinAttempsStorageName?: string, timePinLockedStorageName?: string): Promise<any>;
+export declare function hasUserSetPinCode(serviceName?: string): Promise<boolean>;
+export declare function deleteUserPinCode(serviceName?: string): Promise<void>;
+export declare function resetPinCodeInternalStates(pinAttempsStorageName?: string, timePinLockedStorageName?: string): Promise<void>;
 export default PINCode;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.resetPinCodeInternalStates = exports.deleteUserPinCode = exports.hasUserSetPinCode = void 0;
 const ApplicationLocked_1 = require("./src/ApplicationLocked");
 const PinCode_1 = require("./src/PinCode");
 const PinCodeChoose_1 = require("./src/PinCodeChoose");

--- a/dist/src/ApplicationLocked.d.ts
+++ b/dist/src/ApplicationLocked.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { PinResultStatus } from "./utils";
 import * as React from "react";
 export declare type IProps = {
@@ -40,11 +41,11 @@ declare class ApplicationLocked extends React.PureComponent<IProps, IState> {
     componentDidMount(): void;
     timer(): Promise<void>;
     componentWillUnmount(): void;
-    renderButton: () => any;
-    renderTimer: (minutes: number, seconds: number) => any;
-    renderTitle: () => any;
-    renderIcon: () => any;
-    renderErrorLocked: () => any;
-    render(): any;
+    renderButton: () => JSX.Element;
+    renderTimer: (minutes: number, seconds: number) => JSX.Element;
+    renderTitle: () => JSX.Element;
+    renderIcon: () => JSX.Element;
+    renderErrorLocked: () => JSX.Element;
+    render(): JSX.Element;
 }
 export default ApplicationLocked;

--- a/dist/src/PinCode.d.ts
+++ b/dist/src/PinCode.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import * as React from "react";
 import { StyleProp, TextStyle, ViewStyle } from "react-native";
 /**
@@ -79,7 +80,7 @@ export interface IState {
 export declare enum PinStatus {
     choose = "choose",
     confirm = "confirm",
-    enter = "enter"
+    enter = "enter",
 }
 declare class PinCode extends React.PureComponent<IProps, IState> {
     static defaultProps: Partial<IProps>;
@@ -91,14 +92,14 @@ declare class PinCode extends React.PureComponent<IProps, IState> {
     failedAttempt: () => Promise<void>;
     newAttempt: () => Promise<void>;
     onPressButtonNumber: (text: string) => Promise<void>;
-    renderButtonNumber: (text: string) => any;
+    renderButtonNumber: (text: string) => JSX.Element;
     endProcess: (pwd: string) => void;
     doShake(): Promise<void>;
     showError(isErrorValidation?: boolean): Promise<void>;
-    renderCirclePassword: () => any;
-    renderButtonDelete: (opacity: number) => any;
-    renderTitle: (colorTitle: string, opacityTitle: number, attemptFailed?: boolean, showError?: boolean) => any;
-    renderSubtitle: (colorTitle: string, opacityTitle: number, attemptFailed?: boolean, showError?: boolean) => any;
-    render(): any;
+    renderCirclePassword: () => JSX.Element;
+    renderButtonDelete: (opacity: number) => JSX.Element;
+    renderTitle: (colorTitle: string, opacityTitle: number, attemptFailed?: boolean, showError?: boolean) => JSX.Element;
+    renderSubtitle: (colorTitle: string, opacityTitle: number, attemptFailed?: boolean, showError?: boolean) => JSX.Element;
+    render(): JSX.Element;
 }
 export default PinCode;

--- a/dist/src/PinCode.js
+++ b/dist/src/PinCode.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.PinStatus = void 0;
 const delay_1 = require("./delay");
 const colors_1 = require("./design/colors");
 const grid_1 = require("./design/grid");

--- a/dist/src/PinCodeChoose.d.ts
+++ b/dist/src/PinCodeChoose.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { PinStatus } from './PinCode';
 import * as React from 'react';
 import { StyleProp, TextStyle, ViewStyle } from 'react-native';
@@ -75,6 +76,6 @@ declare class PinCodeChoose extends React.PureComponent<IProps, IState> {
     endProcessCreation: (pinCode: string, isErrorValidation?: boolean) => void;
     endProcessConfirm: (pinCode: string) => Promise<void>;
     cancelConfirm: () => void;
-    render(): any;
+    render(): JSX.Element;
 }
 export default PinCodeChoose;

--- a/dist/src/PinCodeEnter.d.ts
+++ b/dist/src/PinCodeEnter.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { PinStatus } from './PinCode';
 import { PinResultStatus } from './utils';
 import * as React from 'react';
@@ -94,6 +95,6 @@ declare class PinCodeEnter extends React.PureComponent<IProps, IState> {
     triggerTouchID(): void;
     endProcess: (pinCode?: string) => Promise<void>;
     launchTouchID(): Promise<void>;
-    render(): any;
+    render(): JSX.Element;
 }
 export default PinCodeEnter;

--- a/dist/src/PinCodeEnter.js
+++ b/dist/src/PinCodeEnter.js
@@ -19,7 +19,7 @@ class PinCodeEnter extends React.PureComponent {
             else {
                 let pinValidOverride = undefined;
                 if (this.props.handleResult) {
-                    pinValidOverride = Promise.resolve(this.props.handleResult(pinCode));
+                    pinValidOverride = await Promise.resolve(this.props.handleResult(pinCode));
                 }
                 this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
                 this.props.changeInternalStatus(utils_1.PinResultStatus.initial);

--- a/dist/src/PinCodeEnter.js
+++ b/dist/src/PinCodeEnter.js
@@ -17,15 +17,16 @@ class PinCodeEnter extends React.PureComponent {
                 this.props.endProcessFunction(pinCode);
             }
             else {
+                let pinValidOverride = undefined;
                 if (this.props.handleResult) {
-                    this.props.handleResult(pinCode);
+                    pinValidOverride = Promise.resolve(this.props.handleResult(pinCode));
                 }
                 this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
                 this.props.changeInternalStatus(utils_1.PinResultStatus.initial);
                 const pinAttemptsStr = await async_storage_1.default.getItem(this.props.pinAttemptsAsyncStorageName);
                 let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0;
                 const pin = this.props.storedPin || this.keyChainResult;
-                if (pin === pinCode) {
+                if (pinValidOverride !== undefined ? pinValidOverride : pin === pinCode) {
                     this.setState({ pinCodeStatus: utils_1.PinResultStatus.success });
                     async_storage_1.default.multiRemove([
                         this.props.pinAttemptsAsyncStorageName,

--- a/dist/src/delay.d.ts
+++ b/dist/src/delay.d.ts
@@ -1,2 +1,2 @@
-declare const delay: (ms: number) => Promise<unknown>;
+declare const delay: (ms: number) => Promise<{}>;
 export default delay;

--- a/dist/src/design/colors.js
+++ b/dist/src/design/colors.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.documentColor = exports.colors = void 0;
 const colors = {
     red: '#FC4349',
     alert: '#FC4349',

--- a/dist/src/design/grid.js
+++ b/dist/src/design/grid.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.grid = void 0;
 const grid = {
     unit: 16,
     headline: 32,

--- a/dist/src/utils.d.ts
+++ b/dist/src/utils.d.ts
@@ -1,10 +1,15 @@
+import * as Keychain from 'react-native-keychain';
 export declare enum PinResultStatus {
     initial = "initial",
     success = "success",
     failure = "failure",
-    locked = "locked"
+    locked = "locked",
 }
-export declare const hasPinCode: (serviceName: string) => Promise<any>;
-export declare const deletePinCode: (serviceName: string) => Promise<any>;
-export declare const resetInternalStates: (asyncStorageKeys: string[]) => Promise<any>;
-export declare const noBiometricsConfig: any;
+export declare const hasPinCode: (serviceName: string) => Promise<boolean>;
+export declare const deletePinCode: (serviceName: string) => Promise<void>;
+export declare const resetInternalStates: (asyncStorageKeys: string[]) => Promise<void>;
+export declare const noBiometricsConfig: {
+    accessControl: Keychain.ACCESS_CONTROL;
+} | {
+    accessControl?: undefined;
+};

--- a/dist/src/utils.js
+++ b/dist/src/utils.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.noBiometricsConfig = exports.resetInternalStates = exports.deletePinCode = exports.hasPinCode = exports.PinResultStatus = void 0;
 const react_native_1 = require("react-native");
 const async_storage_1 = require("@react-native-community/async-storage");
 const Keychain = require("react-native-keychain");

--- a/src/PinCodeEnter.tsx
+++ b/src/PinCodeEnter.tsx
@@ -157,7 +157,7 @@ class PinCodeEnter extends React.PureComponent<IProps, IState> {
     } else {
       let pinValidOverride = undefined;
       if (this.props.handleResult) {
-        pinValidOverride = Promise.resolve(this.props.handleResult(pinCode));
+        pinValidOverride = await Promise.resolve(this.props.handleResult(pinCode));
       }
       this.setState({ pinCodeStatus: PinResultStatus.initial })
       this.props.changeInternalStatus(PinResultStatus.initial)

--- a/src/PinCodeEnter.tsx
+++ b/src/PinCodeEnter.tsx
@@ -155,8 +155,9 @@ class PinCodeEnter extends React.PureComponent<IProps, IState> {
     if (!!this.props.endProcessFunction) {
       this.props.endProcessFunction(pinCode as string)
     } else {
+      let pinValidOverride = undefined;
       if (this.props.handleResult) {
-        this.props.handleResult(pinCode)
+        pinValidOverride = Promise.resolve(this.props.handleResult(pinCode));
       }
       this.setState({ pinCodeStatus: PinResultStatus.initial })
       this.props.changeInternalStatus(PinResultStatus.initial)
@@ -165,7 +166,7 @@ class PinCodeEnter extends React.PureComponent<IProps, IState> {
       )
       let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0
       const pin = this.props.storedPin || this.keyChainResult
-      if (pin === pinCode) {
+      if (pinValidOverride !== undefined ? pinValidOverride : pin === pinCode) {
         this.setState({ pinCodeStatus: PinResultStatus.success })
         AsyncStorage.multiRemove([
           this.props.pinAttemptsAsyncStorageName,


### PR DESCRIPTION
Simple support for external PIN validation 

handleResultEnterPin can now optionally return bolean to override internal pin validity check

resolves #153 and hopefully resolves #155
